### PR TITLE
Automate test manifest generation

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # install schematic
-pip install schematicpy==24.1.1
+pip install schematicpy==24.2.1

--- a/.github/workflows/schema-convert-ci.yml
+++ b/.github/workflows/schema-convert-ci.yml
@@ -19,7 +19,9 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with: 
+          fetch-depth: 0
       - uses: actions/setup-python@v4 
         with:
           python-version: '3.10'

--- a/.github/workflows/schema-convert-ci.yml
+++ b/.github/workflows/schema-convert-ci.yml
@@ -1,5 +1,6 @@
 # This workflow is used to convert changed AD.model.csv to AD.model.jsonld
-# and push the updated jsonld to feature branch
+# and push the updated jsonld to feature branch. It also generates a test report
+# on any changed manifests, with links to manifests.
 
 name: CI
 
@@ -34,10 +35,6 @@ jobs:
       - name: Assemble csv data model
         run: python scripts/assemble_csv_data_model.py modules AD.model.csv
 
-      - uses: r-lib/actions/pr-fetch@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Commit csv changes
         run: |
           git config --local user.name "$GITHUB_ACTOR"
@@ -56,6 +53,42 @@ jobs:
           git add AD.model.jsonld
           git commit -m "GitHub Action: convert *.model.csv to *.model.jsonld" || echo "No changes to commit"
 
-      - uses: r-lib/actions/pr-push@v2
+      - name: Push model changes
+        uses: r-lib/actions/pr-push@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+    
+      - name: List changed attributes
+        run: git diff --name-only > ./tests/changed-files.txt 
+
+      - name: Identify changed manifests
+        run: python ./scripts/identify_changed_manifests_for_testing.py \
+          --changed_files_path ./tests/changed-files.txt \
+          --current_templates_url https://raw.githubusercontent.com/adknowledgeportal/data-models/main/modules/template/templates.csv \
+          --new_templates_path ./modules/template/templates.csv \
+          --csv_model_path ./AD.model.csv \
+          --template_config_path ./dca-template-config.json \
+          --output_file_path ./tests/changed-templates.json
+
+      - name: Generate test manifests
+        working-directory: tests
+        continue-on-error: true
+        run: ./generate_all_manifests.sh
+
+      - name: Create test suite report
+        working-directory: tests
+        continue-on-error: true
+        run: docker run -v $(pwd):/tests rocker/tidyverse R -e "rmarkdown::render('tests/test-suite-report.Rmd')"
+
+      - name: Report on test suite as PR comment
+        uses: mshick/add-pr-comment@v2
+        with:
+          message-id: test-suite-report
+          message-path: |
+            tests/test-suite-report.md
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-logs
+          path: tests/**/logs

--- a/.github/workflows/schema-convert-ci.yml
+++ b/.github/workflows/schema-convert-ci.yml
@@ -6,8 +6,10 @@ name: CI
 on:
   pull_request:
     branches: main
-    # runs on changes to data model csv only
+    # runs on changes to module csvs
     paths: 'modules/**'
+
+  workflow_dispatch:
 
 jobs:
   CI:

--- a/.gitignore
+++ b/.gitignore
@@ -25,10 +25,13 @@ tests/creds.json
 tests/AD.model.jsonld
 tests/**/logs
 tests/test-suite-report.md
+tests/changed-files.txt
+tests/changed-templates.json
 
 # ignore mac files
 .DS_Store
 **/.DS_Store
 
-# ignore scratch jupyter nb for now
+# ignore some scratch files
 scripts/add_cohort_attribute.ipynb
+tests/example-manifest-selection.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.26.4
 pandas==1.5.3
 synapseclient==3.2.0
-schematicpy==24.1.1
+schematicpy==24.2.1

--- a/scripts/identify_changed_manifests_for_testing.py
+++ b/scripts/identify_changed_manifests_for_testing.py
@@ -1,0 +1,69 @@
+
+import os
+import pandas as pd
+import json
+import argparse
+
+
+def get_templates_with_changed_attributes(csv_model_path: str, changed_attributes:list) -> list:
+    csv_model = pd.read_csv(csv_model_path)
+    changed_attributes_regex = '|'.join(changed_attributes)
+    templates_with_changed_attributes = csv_model[csv_model['DependsOn'].str.contains(changed_attributes_regex, na = False)]['Attribute'].to_list()
+    return templates_with_changed_attributes
+
+
+def compare_template_module(current_templates_url: str, new_templates_path: str) -> list:
+    current_templates = pd.read_csv(current_templates_url, index_col = 0)
+    new_templates = pd.read_csv(new_templates_path, index_col = 0)
+    comp = new_templates.compare(current_templates, align_axis = 0)
+    changed_template_names = comp.index.get_level_values(0).to_list()
+    return changed_template_names
+
+
+def write_test_template_json(template_config_path: str, test_templates: set, output_file_path: str):
+    template_config = json.load(open(template_config_path))
+    filtered_templates = [x for x in template_config['manifest_schemas'] if (x['display_name']) in (test_templates)]
+    file = open(output_file_path, "w")
+    json.dump(filtered_templates, file)
+
+
+def main(args):
+
+    changed_files_path = args.changed_files_path
+    current_templates_url = args.current_templates_url
+    new_templates_path = args.new_templates_path
+    csv_model_path = args.csv_model_path
+    template_config_path = args.template_config_path
+    output_file_path = args.output_file_path
+
+    changed_files = open(changed_files_path, 'r')
+
+    changed_attributes = list()
+    changed_templates = list()
+
+    for x in changed_files:
+        value = os.path.splitext(os.path.basename(x))[0]
+        if value == 'templates' :
+            changed_template_names = compare_template_module(current_templates_url, new_templates_path)
+            changed_templates = changed_templates + changed_template_names
+        else: 
+            changed_attributes.append(value)
+
+    test_templates = set(changed_templates + 
+                        get_templates_with_changed_attributes(csv_model_path, changed_attributes))
+
+    write_test_template_json(template_config_path, test_templates, output_file_path)
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate a JSON array of manifest templates with changes relative to adkp/data-model/main.")
+    parser.add_argument("--changed_files_path", help="path to changed-files.txt output of git diff --name-only", default="./tests/changed-files.txt")
+    parser.add_argument("--current_templates_url", help="raw Github url to the currently in-use templates.csv attribute of the data model")
+    parser.add_argument("--new_templates_path", help="path to modules/template/templates.csv")
+    parser.add_argument("--csv_model_path", help="path to csv data model")
+    parser.add_argument("--template_config_path", help="path to dca-template-config.json file")
+    parser.add_argument("--output_file_path", help="path to write json file of manifests to generate")
+
+    args = parser.parse_args()
+    main(args)

--- a/tests/example-manifest-selection.sh
+++ b/tests/example-manifest-selection.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# don't call this, just copy and paste
+
+python ./scripts/identify_changed_manifests_for_testing.py \
+    --changed_files_path ./tests/changed-files.txt \
+    --current_templates_url https://raw.githubusercontent.com/adknowledgeportal/data-models/main/modules/template/templates.csv \
+    --new_templates_path ./modules/template/templates.csv \
+    --csv_model_path ./AD.model.csv \
+    --template_config_path ./dca-template-config.json \
+    --output_file_path ./tests/changed-templates.json

--- a/tests/generate_all_manifests.sh
+++ b/tests/generate_all_manifests.sh
@@ -2,14 +2,15 @@
 # Test generate GoogleSheets templates
 # run with ./generate_all_manifests.sh from tests directory
 
-TEST_CONFIG_PATH=../dca-template-config.json
-TEST_CONFIG=dca-template-config.json
+# TEST_CONFIG_PATH=../dca-template-config.json
+# TEST_CONFIG=dca-template-config.json
+CHANGED_TEMPLATE_CONFIG=changed-templates.json
 CREDS_PATH=../schematic_service_account_creds.json
 CREDS=schematic_service_account_creds.json
 DATA_MODEL_PATH=../AD.model.jsonld
 DATA_MODEL=AD.model.jsonld
 LOG_DIR=logs
-SLEEP_THROTTLE=17 # API rate-limiting, need to better figure out dynamically based on # of templates
+SLEEP_THROTTLE=10 # API rate-limiting, need to better figure out dynamically based on # of templates
 
 # Setup for creds
 cp $CREDS_PATH $CREDS
@@ -28,12 +29,15 @@ else
 fi
 
 # Set up templates config
-cp $TEST_CONFIG_PATH $TEST_CONFIG
-echo "✓ Using copy of $TEST_CONFIG_PATH for test"
+# cp $TEST_CONFIG_PATH $TEST_CONFIG
+# echo "✓ Using copy of $TEST_CONFIG_PATH for test"
 
-TEMPLATES=($(jq '.manifest_schemas[] | .schema_name' $TEST_CONFIG | tr -d '"'))
-#TITLES=($(jq '.manifest_schemas[] | .display_name' $TEST_CONFIG | tr -d '"'))
-echo "✓ Using config with ${#TEMPLATES[@]} templates..."
+# TEMPLATES=($(jq '.manifest_schemas[] | .schema_name' $TEST_CONFIG | tr -d '"'))
+# #TITLES=($(jq '.manifest_schemas[] | .display_name' $TEST_CONFIG | tr -d '"'))
+# echo "✓ Using config with ${#TEMPLATES[@]} templates..."
+
+CHANGED_TEMPLATES=($(jq '.[] | .schema_name' $CHANGED_TEMPLATE_CONFIG | tr -d '"'))
+echo "✓ Using ${#CHANGED_TEMPLATES[@]} templates from $CHANGED_TEMPLATE_CONFIG..."
 
 # Setup data model
 cp $DATA_MODEL_PATH $DATA_MODEL
@@ -42,10 +46,10 @@ echo "✓ Set up $DATA_MODEL for test"
 # Setup logs
 mkdir -p $LOG_DIR
 
-for i in ${!TEMPLATES[@]}
+for i in ${!CHANGED_TEMPLATES[@]}
 do
-  echo ">>>>>>> Generating ${TEMPLATES[$i]}"
-  schematic manifest --config ../schematic-config.yml get -dt "${TEMPLATES[$i]}" --title "${TEMPLATES[$i]}" -s | tee $LOG_DIR/${TEMPLATES[$i]%.*}_log
+  echo ">>>>>>> Generating ${CHANGED_TEMPLATES[$i]}"
+  schematic manifest --config ../schematic-config.yml get -dt "${CHANGED_TEMPLATES[$i]}" --title "${CHANGED_TEMPLATES[$i]}" -s | tee $LOG_DIR/${CHANGED_TEMPLATES[$i]%.*}_log
   sleep $SLEEP_THROTTLE
 done
 

--- a/tests/generate_test_manifests.sh
+++ b/tests/generate_test_manifests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Test generate GoogleSheets templates
-# run with ./generate_all_manifests.sh from tests directory
+# generate GoogleSheets templates
+# if using locally run with ./generate_all_manifests.sh from tests directory
 
 # TEST_CONFIG_PATH=../dca-template-config.json
 # TEST_CONFIG=dca-template-config.json

--- a/tests/test-suite-report.Rmd
+++ b/tests/test-suite-report.Rmd
@@ -12,7 +12,7 @@ test_reaction <- function(pass) {
   if(is.na(pass)) { 
     ":zzz:" # potentially skipped tests
   } else if(pass) {
-    ":smile:" 
+    ":white_check_mark:" 
   } else { 
     ":x:"
   }
@@ -24,6 +24,8 @@ md_link <- function (url) {
 ```
 
 ## Template Generation
+
+The following manifest templates had at least one dependency with changes detected:
 
 ```{r parse-generation-logs, echo=FALSE}
 gen_logs <- list.files("./logs", full.names = TRUE)
@@ -37,7 +39,7 @@ gen_report <- data.frame(template = templates,
 knitr::kable(gen_report)
 ```
 
-## Manifest Validation 
+## :construction: Manifest Validation - COMING SOON
 
 ```{r parse-validation-logs, echo=FALSE, eval = FALSE}
 


### PR DESCRIPTION
This adds another several steps to our CI github action, which runs on any pull request with changes to `modules/`.

After compiling the csv model from the modules and converting to json-ld, the action:
- identifies which attribute csvs have changes
- finds all manifest templates that depend on those attributes
- generates those changed manifest templates as google sheets
- compiles a report with the status of each manifest generation and a link to the google sheet, if successful
- adds a comment to the PR with a md version of the report
