### PR TITLE
remove test value

### DIFF
--- a/AD.model.csv
+++ b/AD.model.csv
@@ -422,7 +422,6 @@ Sparse Possible C1,Sparse Possible C1,,,,,CERAD,,ADSP,,string,clinical
 mitochondrial,A chromosome found in the mitochondrion of a eukaryotic cell.,,,,,chromosome,,http://purl.obolibrary.org/obo/GO_0000262,,string,sequencing
 X,Chromosome X,,,,,chromosome,,Sage Bionetworks,,string,sequencing
 Y,Chromosome Y,,,,,chromosome,,Sage Bionetworks,,string,sequencing
-AAAA_test_cohort,test cohort only,,,,False,cohort,,fake,,string,clinical
 ABC-DS,Alzheimer's Biomarkers Consortium - Down Syndrome,,,,False,cohort,,https://www.abcds.pitt.edu/,,string,clinical
 ACT,Adult Changes in Thought - Kaiser Permanente Washington Health Research Institute,,,,False,cohort,,https://actagingresearch.org/about,,string,clinical
 ADNI,Alzheimer's Disease Neuroimaging Initative,,,,False,cohort,,https://adni.loni.usc.edu/,,string,clinical
@@ -850,7 +849,7 @@ chromatinAmount,Amount in ug of chromatin used for an assay,,,,False,ManifestCol
 chromatinAmountUnits,Units of measure for the amount of chromatin used for an assay,,,,False,ManifestColumn,,sage.annotations-immunoAssays.chromatinAmountUnits-0.0.2,,string,sequencing
 chromosome,A structure composed of a very long molecule of DNA and associated proteins (e.g. histones) that carries hereditary information; number or designation of the particular chromosome that the data is associated with.,"1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, X, Y, mitochondrial",,,False,ManifestColumn,,sage.annotations-experimentalData.chromosome-0.0.4,,string,sequencing
 climbID,Identifying string linked to an animal in Climb database,,,,True,ManifestColumn,,sage.annotations-neuro.climbID-0.0.1,,string,MODEL-AD
-cohort,A study group population where the members are human beings who meet inclusion criteria.,"AAAA_test_cohort,ABC-DS,ACT,ADNI,Banner,BEB-Miller,Biggs Institute Brain Bank,BLSA,CHDWB,CLINCOR,Columbia ADRC,DiCAD,EFIGA,EHBS,Emory ADRC,FBS,Framingham,HBCC,HBTRC,HPGP,HUP,LBP,MARS,Mayo Clinic,MC,MCJ,MCR,MSBB,NYBB,Pitt ADRC,RADC,ROSMAP,SMRI,UFL,UK Biobank,UPBB,UPenn,UW ADRC,WHICAP",,,False,ManifestColumn,,http://purl.obolibrary.org/obo/STATO_0000203,,string,clinical
+cohort,A study group population where the members are human beings who meet inclusion criteria.,"ABC-DS,ACT,ADNI,Banner,BEB-Miller,Biggs Institute Brain Bank,BLSA,CHDWB,CLINCOR,Columbia ADRC,DiCAD,EFIGA,EHBS,Emory ADRC,FBS,Framingham,HBCC,HBTRC,HPGP,HUP,LBP,MARS,Mayo Clinic,MC,MCJ,MCR,MSBB,NYBB,Pitt ADRC,RADC,ROSMAP,SMRI,UFL,UK Biobank,UPBB,UPenn,UW ADRC,WHICAP",,,False,ManifestColumn,,http://purl.obolibrary.org/obo/STATO_0000203,,string,clinical
 conservationMethod,The conservation method,"noConservation, fixed tissues only, frozen tissue only, both fixed and frozen tissue, missing or unknown",,,True,ManifestColumn,,sage-annotations-clinical.conservationMethod-0.0.2,string,,clinical
 consortium,The name of the consortium,"CMC, PEC, AMP-AD, MODEL-AD, M2OVE-AD, Resilience-AD, BSMN, CSBC, PSON, GENIE, Synodos, DHART SPORE, CDCP, Psych-AD, ELITE, Not Applicable",,,True,ManifestColumn,,sage.annotations-sageCommunity.consortium-0.0.5,,string,ADKP
 contrastAgent,Substance administered during an imaging procedure that allows delineation of internal structures.,,,,False,ManifestColumn,,sage.annotations-experimentalData.contrastAgent-0.0.2,,string,imaging

--- a/AD.model.jsonld
+++ b/AD.model.jsonld
@@ -9909,169 +9909,16 @@
             "sms:validationRules": []
         },
         {
-            "@id": "bts:AAAATestCohort",
-            "@type": "rdfs:Class",
-            "rdfs:comment": "test cohort only",
-            "rdfs:label": "AAAATestCohort",
-            "rdfs:subClassOf": [
-                {
-                    "@id": "bts:Cohort"
-                }
-            ],
-            "schema:isPartOf": {
-                "@id": "http://schema.biothings.io"
-            },
-            "sms:displayName": "AAAA_test_cohort",
-            "sms:required": "sms:false",
-            "sms:validationRules": []
-        },
-        {
-            "@id": "bts:Cohort",
-            "@type": "rdfs:Class",
-            "rdfs:comment": "A study group population where the members are human beings who meet inclusion criteria.",
-            "rdfs:label": "Cohort",
-            "rdfs:subClassOf": [
-                {
-                    "@id": "bts:ManifestColumn"
-                }
-            ],
-            "schema:isPartOf": {
-                "@id": "http://schema.biothings.io"
-            },
-            "schema:rangeIncludes": [
-                {
-                    "@id": "bts:AAAATestCohort"
-                },
-                {
-                    "@id": "bts:ABC-DS"
-                },
-                {
-                    "@id": "bts:ACT"
-                },
-                {
-                    "@id": "bts:ADNI"
-                },
-                {
-                    "@id": "bts:Banner"
-                },
-                {
-                    "@id": "bts:BEB-Miller"
-                },
-                {
-                    "@id": "bts:BiggsInstituteBrainBank"
-                },
-                {
-                    "@id": "bts:BLSA"
-                },
-                {
-                    "@id": "bts:CHDWB"
-                },
-                {
-                    "@id": "bts:CLINCOR"
-                },
-                {
-                    "@id": "bts:ColumbiaADRC"
-                },
-                {
-                    "@id": "bts:DiCAD"
-                },
-                {
-                    "@id": "bts:EFIGA"
-                },
-                {
-                    "@id": "bts:EHBS"
-                },
-                {
-                    "@id": "bts:EmoryADRC"
-                },
-                {
-                    "@id": "bts:FBS"
-                },
-                {
-                    "@id": "bts:Framingham"
-                },
-                {
-                    "@id": "bts:HBCC"
-                },
-                {
-                    "@id": "bts:HBTRC"
-                },
-                {
-                    "@id": "bts:HPGP"
-                },
-                {
-                    "@id": "bts:HUP"
-                },
-                {
-                    "@id": "bts:LBP"
-                },
-                {
-                    "@id": "bts:MARS"
-                },
-                {
-                    "@id": "bts:MayoClinic"
-                },
-                {
-                    "@id": "bts:MC"
-                },
-                {
-                    "@id": "bts:MCJ"
-                },
-                {
-                    "@id": "bts:MCR"
-                },
-                {
-                    "@id": "bts:MSBB"
-                },
-                {
-                    "@id": "bts:NYBB"
-                },
-                {
-                    "@id": "bts:PittADRC"
-                },
-                {
-                    "@id": "bts:RADC"
-                },
-                {
-                    "@id": "bts:ROSMAP"
-                },
-                {
-                    "@id": "bts:SMRI"
-                },
-                {
-                    "@id": "bts:UFL"
-                },
-                {
-                    "@id": "bts:UKBiobank"
-                },
-                {
-                    "@id": "bts:UPBB"
-                },
-                {
-                    "@id": "bts:UPenn"
-                },
-                {
-                    "@id": "bts:UWADRC"
-                },
-                {
-                    "@id": "bts:WHICAP"
-                }
-            ],
-            "sms:displayName": "cohort",
-            "sms:required": "sms:false",
-            "sms:validationRules": []
-        },
-        {
             "@id": "bts:ABC-DS",
             "@type": "rdfs:Class",
             "rdfs:comment": "The Alzheimer's Biomarkers Consortium - Down Syndrome (ABC-DS) Study",
             "rdfs:label": "ABC-DS",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:Study"
+                    "@id": "bts:Cohort"
                 },
                 {
-                    "@id": "bts:Cohort"
+                    "@id": "bts:Study"
                 }
             ],
             "schema:isPartOf": {
@@ -10306,6 +10153,139 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "BEB-Miller",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Cohort",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "A study group population where the members are human beings who meet inclusion criteria.",
+            "rdfs:label": "Cohort",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:ManifestColumn"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "schema:rangeIncludes": [
+                {
+                    "@id": "bts:ABC-DS"
+                },
+                {
+                    "@id": "bts:ACT"
+                },
+                {
+                    "@id": "bts:ADNI"
+                },
+                {
+                    "@id": "bts:Banner"
+                },
+                {
+                    "@id": "bts:BEB-Miller"
+                },
+                {
+                    "@id": "bts:BiggsInstituteBrainBank"
+                },
+                {
+                    "@id": "bts:BLSA"
+                },
+                {
+                    "@id": "bts:CHDWB"
+                },
+                {
+                    "@id": "bts:CLINCOR"
+                },
+                {
+                    "@id": "bts:ColumbiaADRC"
+                },
+                {
+                    "@id": "bts:DiCAD"
+                },
+                {
+                    "@id": "bts:EFIGA"
+                },
+                {
+                    "@id": "bts:EHBS"
+                },
+                {
+                    "@id": "bts:EmoryADRC"
+                },
+                {
+                    "@id": "bts:FBS"
+                },
+                {
+                    "@id": "bts:Framingham"
+                },
+                {
+                    "@id": "bts:HBCC"
+                },
+                {
+                    "@id": "bts:HBTRC"
+                },
+                {
+                    "@id": "bts:HPGP"
+                },
+                {
+                    "@id": "bts:HUP"
+                },
+                {
+                    "@id": "bts:LBP"
+                },
+                {
+                    "@id": "bts:MARS"
+                },
+                {
+                    "@id": "bts:MayoClinic"
+                },
+                {
+                    "@id": "bts:MC"
+                },
+                {
+                    "@id": "bts:MCJ"
+                },
+                {
+                    "@id": "bts:MCR"
+                },
+                {
+                    "@id": "bts:MSBB"
+                },
+                {
+                    "@id": "bts:NYBB"
+                },
+                {
+                    "@id": "bts:PittADRC"
+                },
+                {
+                    "@id": "bts:RADC"
+                },
+                {
+                    "@id": "bts:ROSMAP"
+                },
+                {
+                    "@id": "bts:SMRI"
+                },
+                {
+                    "@id": "bts:UFL"
+                },
+                {
+                    "@id": "bts:UKBiobank"
+                },
+                {
+                    "@id": "bts:UPBB"
+                },
+                {
+                    "@id": "bts:UPenn"
+                },
+                {
+                    "@id": "bts:UWADRC"
+                },
+                {
+                    "@id": "bts:WHICAP"
+                }
+            ],
+            "sms:displayName": "cohort",
             "sms:required": "sms:false",
             "sms:validationRules": []
         },
@@ -10791,10 +10771,10 @@
             "rdfs:label": "SMRI",
             "rdfs:subClassOf": [
                 {
-                    "@id": "bts:IndividualIdSource"
+                    "@id": "bts:Cohort"
                 },
                 {
-                    "@id": "bts:Cohort"
+                    "@id": "bts:IndividualIdSource"
                 }
             ],
             "schema:isPartOf": {

--- a/modules/clinical/cohort.csv
+++ b/modules/clinical/cohort.csv
@@ -1,6 +1,5 @@
 Attribute,Description,Valid Values,DependsOn,Properties,Required,Parent,DependsOn Component,Source,Validation Rules,columnType,module
-cohort,A study group population where the members are human beings who meet inclusion criteria.,"AAAA_test_cohort,ABC-DS,ACT,ADNI,Banner,BEB-Miller,Biggs Institute Brain Bank,BLSA,CHDWB,CLINCOR,Columbia ADRC,DiCAD,EFIGA,EHBS,Emory ADRC,FBS,Framingham,HBCC,HBTRC,HPGP,HUP,LBP,MARS,Mayo Clinic,MC,MCJ,MCR,MSBB,NYBB,Pitt ADRC,RADC,ROSMAP,SMRI,UFL,UK Biobank,UPBB,UPenn,UW ADRC,WHICAP",,,False,ManifestColumn,,http://purl.obolibrary.org/obo/STATO_0000203,,string,clinical
-AAAA_test_cohort,test cohort only,,,,False,cohort,,fake,,string,clinical
+cohort,A study group population where the members are human beings who meet inclusion criteria.,"ABC-DS,ACT,ADNI,Banner,BEB-Miller,Biggs Institute Brain Bank,BLSA,CHDWB,CLINCOR,Columbia ADRC,DiCAD,EFIGA,EHBS,Emory ADRC,FBS,Framingham,HBCC,HBTRC,HPGP,HUP,LBP,MARS,Mayo Clinic,MC,MCJ,MCR,MSBB,NYBB,Pitt ADRC,RADC,ROSMAP,SMRI,UFL,UK Biobank,UPBB,UPenn,UW ADRC,WHICAP",,,False,ManifestColumn,,http://purl.obolibrary.org/obo/STATO_0000203,,string,clinical
 ABC-DS,Alzheimer's Biomarkers Consortium - Down Syndrome,,,,False,cohort,,https://www.abcds.pitt.edu/,,string,clinical
 ACT,Adult Changes in Thought - Kaiser Permanente Washington Health Research Institute,,,,False,cohort,,https://actagingresearch.org/about,,string,clinical
 ADNI,Alzheimer's Disease Neuroimaging Initative,,,,False,cohort,,https://adni.loni.usc.edu/,,string,clinical


### PR DESCRIPTION
The test of the reactive dictionary app worked (https://github.com/Sage-Bionetworks/amp-ad-metadata-dictionary/pull/21), so I'm now removing the dummy valid value for cohort. 