### PR TITLE
Update generate-current-manifests.yml with new secret

### DIFF
--- a/.github/workflows/generate-current-manifests.yml
+++ b/.github/workflows/generate-current-manifests.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with: 
           fetch-depth: 0
+          token: ${{ secrets.ACTION_MANIFEST_GENERATE }}
       - uses: actions/setup-python@v4 
         with:
           python-version: '3.10'


### PR DESCRIPTION
to push new manifests generated by GitHub Actions to main, which is protected