### PR TITLE
bump schematic version to 24.11.2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
-  "hostRequirements": {
-    "cpus": 4,
-    "memory": "4gb",
-    "storage": "16gb"
-  },
+  "image": "mcr.microsoft.com/devcontainers/python:3.10",
   "features": {
   },
   "postCreateCommand": "bash ./.devcontainer/post-create.sh",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # install schematic and other packages
-pip install -r ../requirements.txt
+pip install -r /workspaces/data-models/requirements.txt

--- a/AD.model.csv
+++ b/AD.model.csv
@@ -491,6 +491,7 @@ PSON,Physical Science in Oncology,,,,,consortium,,https://physics.cancer.gov/,,s
 Psych-AD,Neuropsychiatric Symptoms in Alzheimer's Disease,,,,,consortium,,https://adknowledgeportal.synapse.org/Explore/Programs/DetailsPage?Program=Psych-AD,,string,ADKP
 Resilience-AD,Interdisciplinary Research to Understand the Complex Biology of Resilience to Alzheimer's Disease Risk,,,,,consortium,,https://adknowledgeportal.synapse.org/,,string,ADKP
 Synodos,Data derived from a CTF-Funded Synodos project,,,,,consortium,,https://www.synapse.org/ctf,,string,ADKP
+testvalue,not real,,,,,consortium,,nope,,string,ADKP
 AIBL pool,"The Australian Imaging, Biomarkers, and Lifestyle Flagship Study of Ageing (AIBL) reference pool.",,,,,controlType,,https://aibl.csiro.au/,,string,experimentalData
 Baker pool,The Baker Institute Metabolomics Laboratory reference pool.,,,,,controlType,,https://baker.edu.au/research/laboratories/metabolomics,,string,experimentalData
 blank injection,blank injection,,,,,controlType,,-,,string,experimentalData
@@ -863,7 +864,7 @@ chromosome,A structure composed of a very long molecule of DNA and associated pr
 climbID,Identifying string linked to an animal in Climb database,,,,True,ManifestColumn,,sage.annotations-neuro.climbID-0.0.1,,string,MODEL-AD
 cohort,A study group population where the members are human beings who meet inclusion criteria.,"ABC-DS,ACT,ADNI,ADRC,Banner,BEAM,BEB-Miller,Biggs Institute Brain Bank,BLSA,CHDWB,CLINCOR,Columbia ADRC,DiCAD,EFIGA,EHBS,Emory ADRC,FBS,Framingham,HBCC,HBTRC,HPGP,HUP,LBP,MARS,MARS-WI,Mayo Clinic,MC,MCJ,MCR,MIND,MSBB,NYBB,Pitt ADRC,POINTER,RADC,ROSMAP,SMRI,Tulsa LIBR-1000,UFL,UK Biobank,UPBB,UPenn,UW ADRC,WHICAP",,,False,ManifestColumn,,http://purl.obolibrary.org/obo/STATO_0000203,,string,clinical
 conservationMethod,The conservation method,"noConservation, fixed tissues only, frozen tissue only, both fixed and frozen tissue, missing or unknown",,,True,ManifestColumn,,sage-annotations-clinical.conservationMethod-0.0.2,string,,clinical
-consortium,The name of the consortium,"CMC, PEC, AMP-AD, MODEL-AD, M2OVE-AD, Resilience-AD, BSMN, CSBC, PSON, GENIE, Synodos, DHART SPORE, CDCP, Psych-AD, ELITE, Not Applicable",,,True,ManifestColumn,,sage.annotations-sageCommunity.consortium-0.0.5,,string,ADKP
+consortium,The name of the consortium,"testvalue, CMC, PEC, AMP-AD, MODEL-AD, M2OVE-AD, Resilience-AD, BSMN, CSBC, PSON, GENIE, Synodos, DHART SPORE, CDCP, Psych-AD, ELITE, Not Applicable",,,True,ManifestColumn,,sage.annotations-sageCommunity.consortium-0.0.5,,string,ADKP
 contrastAgent,Substance administered during an imaging procedure that allows delineation of internal structures.,,,,False,ManifestColumn,,sage.annotations-experimentalData.contrastAgent-0.0.2,,string,imaging
 controlType,Control samples suitable for normalization and batch correction,"AIBL pool, Baker pool, blank injection, GIS, GoldenWest, NIST SRM 1950, qc mix, Replicate, study pool, water plus Baker ISTD",,,False,ManifestColumn,,sage.annotations-experimentalData.controlType-0.0.5,,string,experimentalData
 CVD_ART,Arteriolosclerosis,"No CVD_ART, Mild, Moderate, Severe, missing or unknown",,,False,ManifestColumn,,sage-annotations-clinical.CVD_ART-0.0.2,string,,clinical

--- a/AD.model.csv
+++ b/AD.model.csv
@@ -491,7 +491,6 @@ PSON,Physical Science in Oncology,,,,,consortium,,https://physics.cancer.gov/,,s
 Psych-AD,Neuropsychiatric Symptoms in Alzheimer's Disease,,,,,consortium,,https://adknowledgeportal.synapse.org/Explore/Programs/DetailsPage?Program=Psych-AD,,string,ADKP
 Resilience-AD,Interdisciplinary Research to Understand the Complex Biology of Resilience to Alzheimer's Disease Risk,,,,,consortium,,https://adknowledgeportal.synapse.org/,,string,ADKP
 Synodos,Data derived from a CTF-Funded Synodos project,,,,,consortium,,https://www.synapse.org/ctf,,string,ADKP
-testvalue,not real,,,,,consortium,,nope,,string,ADKP
 AIBL pool,"The Australian Imaging, Biomarkers, and Lifestyle Flagship Study of Ageing (AIBL) reference pool.",,,,,controlType,,https://aibl.csiro.au/,,string,experimentalData
 Baker pool,The Baker Institute Metabolomics Laboratory reference pool.,,,,,controlType,,https://baker.edu.au/research/laboratories/metabolomics,,string,experimentalData
 blank injection,blank injection,,,,,controlType,,-,,string,experimentalData
@@ -864,7 +863,7 @@ chromosome,A structure composed of a very long molecule of DNA and associated pr
 climbID,Identifying string linked to an animal in Climb database,,,,True,ManifestColumn,,sage.annotations-neuro.climbID-0.0.1,,string,MODEL-AD
 cohort,A study group population where the members are human beings who meet inclusion criteria.,"ABC-DS,ACT,ADNI,ADRC,Banner,BEAM,BEB-Miller,Biggs Institute Brain Bank,BLSA,CHDWB,CLINCOR,Columbia ADRC,DiCAD,EFIGA,EHBS,Emory ADRC,FBS,Framingham,HBCC,HBTRC,HPGP,HUP,LBP,MARS,MARS-WI,Mayo Clinic,MC,MCJ,MCR,MIND,MSBB,NYBB,Pitt ADRC,POINTER,RADC,ROSMAP,SMRI,Tulsa LIBR-1000,UFL,UK Biobank,UPBB,UPenn,UW ADRC,WHICAP",,,False,ManifestColumn,,http://purl.obolibrary.org/obo/STATO_0000203,,string,clinical
 conservationMethod,The conservation method,"noConservation, fixed tissues only, frozen tissue only, both fixed and frozen tissue, missing or unknown",,,True,ManifestColumn,,sage-annotations-clinical.conservationMethod-0.0.2,string,,clinical
-consortium,The name of the consortium,"testvalue, CMC, PEC, AMP-AD, MODEL-AD, M2OVE-AD, Resilience-AD, BSMN, CSBC, PSON, GENIE, Synodos, DHART SPORE, CDCP, Psych-AD, ELITE, Not Applicable",,,True,ManifestColumn,,sage.annotations-sageCommunity.consortium-0.0.5,,string,ADKP
+consortium,The name of the consortium,"CMC, PEC, AMP-AD, MODEL-AD, M2OVE-AD, Resilience-AD, BSMN, CSBC, PSON, GENIE, Synodos, DHART SPORE, CDCP, Psych-AD, ELITE, Not Applicable",,,True,ManifestColumn,,sage.annotations-sageCommunity.consortium-0.0.5,,string,ADKP
 contrastAgent,Substance administered during an imaging procedure that allows delineation of internal structures.,,,,False,ManifestColumn,,sage.annotations-experimentalData.contrastAgent-0.0.2,,string,imaging
 controlType,Control samples suitable for normalization and batch correction,"AIBL pool, Baker pool, blank injection, GIS, GoldenWest, NIST SRM 1950, qc mix, Replicate, study pool, water plus Baker ISTD",,,False,ManifestColumn,,sage.annotations-experimentalData.controlType-0.0.5,,string,experimentalData
 CVD_ART,Arteriolosclerosis,"No CVD_ART, Mild, Moderate, Severe, missing or unknown",,,False,ManifestColumn,,sage-annotations-clinical.CVD_ART-0.0.2,string,,clinical

--- a/AD.model.jsonld
+++ b/AD.model.jsonld
@@ -11248,9 +11248,6 @@
             },
             "schema:rangeIncludes": [
                 {
-                    "@id": "bts:Testvalue"
-                },
-                {
                     "@id": "bts:CMC"
                 },
                 {
@@ -11850,23 +11847,6 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Synodos",
-            "sms:required": "sms:false",
-            "sms:validationRules": []
-        },
-        {
-            "@id": "bts:Testvalue",
-            "@type": "rdfs:Class",
-            "rdfs:comment": "not real",
-            "rdfs:label": "Testvalue",
-            "rdfs:subClassOf": [
-                {
-                    "@id": "bts:Consortium"
-                }
-            ],
-            "schema:isPartOf": {
-                "@id": "http://schema.biothings.io"
-            },
-            "sms:displayName": "testvalue",
             "sms:required": "sms:false",
             "sms:validationRules": []
         },

--- a/AD.model.jsonld
+++ b/AD.model.jsonld
@@ -11248,6 +11248,9 @@
             },
             "schema:rangeIncludes": [
                 {
+                    "@id": "bts:Testvalue"
+                },
+                {
                     "@id": "bts:CMC"
                 },
                 {
@@ -11847,6 +11850,23 @@
                 "@id": "http://schema.biothings.io"
             },
             "sms:displayName": "Synodos",
+            "sms:required": "sms:false",
+            "sms:validationRules": []
+        },
+        {
+            "@id": "bts:Testvalue",
+            "@type": "rdfs:Class",
+            "rdfs:comment": "not real",
+            "rdfs:label": "Testvalue",
+            "rdfs:subClassOf": [
+                {
+                    "@id": "bts:Consortium"
+                }
+            ],
+            "schema:isPartOf": {
+                "@id": "http://schema.biothings.io"
+            },
+            "sms:displayName": "testvalue",
             "sms:required": "sms:false",
             "sms:validationRules": []
         },

--- a/modules/ADKP/consortium.csv
+++ b/modules/ADKP/consortium.csv
@@ -1,5 +1,5 @@
 Attribute,Description,Valid Values,DependsOn,Properties,Required,Parent,DependsOn Component,Source,Validation Rules,columnType,module
-consortium,The name of the consortium,"testvalue, CMC, PEC, AMP-AD, MODEL-AD, M2OVE-AD, Resilience-AD, BSMN, CSBC, PSON, GENIE, Synodos, DHART SPORE, CDCP, Psych-AD, ELITE, Not Applicable",,,True,ManifestColumn,,sage.annotations-sageCommunity.consortium-0.0.5,,string,ADKP
+consortium,The name of the consortium,"CMC, PEC, AMP-AD, MODEL-AD, M2OVE-AD, Resilience-AD, BSMN, CSBC, PSON, GENIE, Synodos, DHART SPORE, CDCP, Psych-AD, ELITE, Not Applicable",,,True,ManifestColumn,,sage.annotations-sageCommunity.consortium-0.0.5,,string,ADKP
 AMP-AD,Accelerating Medicines Partnership-Alzheimer's Disease,,,,,consortium,,https://adknowledgeportal.synapse.org/,,string,ADKP
 BSMN,Brain Somatic Mosaicism Network,,,,,consortium,,https://www.synapse.org/bsmn,,string,ADKP
 CDCP,Community Data Contribution Program,,,,,consortium,,https://adknowledgeportal.synapse.org/,,string,ADKP
@@ -16,4 +16,3 @@ PSON,Physical Science in Oncology,,,,,consortium,,https://physics.cancer.gov/,,s
 Psych-AD,Neuropsychiatric Symptoms in Alzheimer's Disease,,,,,consortium,,https://adknowledgeportal.synapse.org/Explore/Programs/DetailsPage?Program=Psych-AD,,string,ADKP
 Resilience-AD,Interdisciplinary Research to Understand the Complex Biology of Resilience to Alzheimer's Disease Risk,,,,,consortium,,https://adknowledgeportal.synapse.org/,,string,ADKP
 Synodos,Data derived from a CTF-Funded Synodos project,,,,,consortium,,https://www.synapse.org/ctf,,string,ADKP
-testvalue,not real,,,,,consortium,,nope,,string,ADKP


### PR DESCRIPTION
included a new test value for `consortium` to confirm manifest generation still works