### PR TITLE
[DPE-1647] Replace SYNAPSE_PROJECT_ID with RECORDSET_FOLDER_ID

### DIFF
--- a/.github/workflows/register-schema.yml
+++ b/.github/workflows/register-schema.yml
@@ -55,7 +55,7 @@ jobs:
       pull-requests: write
       contents: write
     env: 
-      SYNAPSE_PROJECT_ID: syn25878249
+      RECORDSET_FOLDER_ID: syn74847000
     steps:
       - uses: actions/checkout@v6
         with:
@@ -150,7 +150,7 @@ jobs:
           
           syn = Synapse()
           syn.login()
-          project_id = os.environ["SYNAPSE_PROJECT_ID"]
+          project_id = os.environ["RECORDSET_FOLDER_ID"]
 
           # All URIs registered in this run, one per line (e.g. "org-SchemaName" or "org-SchemaName-1.0.0")
           json_schema_uris = r'''${{ steps.register.outputs.uris }}'''

--- a/.github/workflows/register-schema.yml
+++ b/.github/workflows/register-schema.yml
@@ -150,7 +150,7 @@ jobs:
           
           syn = Synapse()
           syn.login()
-          project_id = os.environ["RECORDSET_FOLDER_ID"]
+          recordset_folder_id = os.environ["RECORDSET_FOLDER_ID"]
 
           # All URIs registered in this run, one per line (e.g. "org-SchemaName" or "org-SchemaName-1.0.0")
           json_schema_uris = r'''${{ steps.register.outputs.uris }}'''
@@ -173,7 +173,7 @@ jobs:
                   semver = release_tag.lstrip('v')
                   tmp_path = f"/tmp/{data_type}_{semver}.csv"
                   template_df.to_csv(tmp_path, index=False)
-                  folder = Folder(name=f"{data_type}_{semver}", parent_id=project_id).store()
+                  folder = Folder(name=f"{data_type}_{semver}", parent_id=recordset_folder_id).store()
                   record_set = RecordSet(
                       name="Template",
                       description=f"Template for {data_type}",
@@ -185,7 +185,7 @@ jobs:
                   ).store(synapse_client=syn)
               else:
                   # For PR runs, create/overwrite a single unversioned folder
-                  folder = Folder(name=f"{data_type}", parent_id=project_id).store()
+                  folder = Folder(name=f"{data_type}", parent_id=recordset_folder_id).store()
                   tmp_path = f"/tmp/{data_type}.csv"
                   template_df.to_csv(tmp_path, index=False)
                   record_set = RecordSet(


### PR DESCRIPTION
## Problem

Recordsets were being uploaded into a folder with excel templates and it was making it hard for people to find the existing excel templates (which are still being used)

## Solution

* Upload recordsets into their own Synapse folder
* Will migrate existing templates into the folder once merged 